### PR TITLE
Tag a remote commit, not the local one.

### DIFF
--- a/lib/releaser/capistrano/release_tagging.rb
+++ b/lib/releaser/capistrano/release_tagging.rb
@@ -6,7 +6,7 @@ namespace :releaser do
   end
 
   task :tag_deploy_commit do
-    run_locally "bundle exec releaser deploy --push --object=#{branch}"
+    run_locally "bundle exec releaser deploy --push --object=#{real_revision}"
   end
 end
 


### PR DESCRIPTION
Closes #3.
