### PR TITLE
Fetch git describe from provided revision.

### DIFF
--- a/lib/releaser/cli.rb
+++ b/lib/releaser/cli.rb
@@ -57,7 +57,7 @@ module Releaser
     end
 
     def version_from_tag
-      tagline = `git describe --match \"v[0-9]*\" --long`.chomp
+      tagline = `git describe --match \"v[0-9]*\" --long -- #{options.object}`.chomp
       Revision.new(tagline)
     end
 


### PR DESCRIPTION
You can pass it with `--object` option. It is already passed from capistrano recipe.
